### PR TITLE
compile_commands: Fix `nothing to build` issue

### DIFF
--- a/compile_commands/export_compile_commands.bzl
+++ b/compile_commands/export_compile_commands.bzl
@@ -254,7 +254,7 @@ def _compilation_database_impl(ctx):
         mnemonic = "CompileCommands",
     )
 
-    return [OutputGroupInfo(outs = [output])]
+    return [DefaultInfo(files = depset([output]))]
 
 export_compile_commands = rule(
     attrs = {


### PR DESCRIPTION
Output was not part of DefaultInfo, and so was not captured by bazel.